### PR TITLE
Refactor DoorsReloaded for Paper/Purpur/Folia with scheduler abstraction

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,25 @@
+# DoorsReloaded
+
+DoorsReloaded modernises door interactions with lightweight quality-of-life features for modern Paper-family servers.
+
+## Supported servers
+
+- ✅ **Paper** 1.21.x+
+- ✅ **Purpur** 1.21.x+
+- ✅ **Folia** 1.21.x+ (region-threading aware)
+- ❌ Spigot / CraftBukkit (not supported)
+- ❌ Sponge or other non-Paper platforms (not supported)
+
+## Folia awareness
+
+The plugin detects Folia at runtime and uses a scheduler abstraction that delegates door updates to Folia's region scheduler, ensuring all world interactions occur on the correct region threads.
+
+## Building
+
+DoorsReloaded uses Maven. To build the shaded plugin JAR, run:
+
+```bash
+mvn clean package
+```
+
+The resulting artifact is located at `target/DoorsReloaded.jar`.

--- a/pom.xml
+++ b/pom.xml
@@ -7,19 +7,17 @@
     <name>DoorsReloaded</name>
     <artifactId>DoorsReloaded</artifactId>
     <version>1.3.3</version>
-    <description>Auto opens/closes double doors, allows to knock on doors, redstone support, ...</description>
+    <description>Lightweight, modern door behavior for Paper, Purpur, and Folia 1.21.x+.</description>
 
     <properties>
-        <spigot.website>https://www.spigotmc.org/resources/authors/mfnalex.175238/</spigot.website>
-        <spigot.prefix>${project.name}</spigot.prefix>
-        <spigot.main>${project.groupId}.doorsreloaded.Main</spigot.main>
+        <plugin.prefix>${project.name}</plugin.prefix>
+        <plugin.main>${project.groupId}.doorsreloaded.Main</plugin.main>
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <java.version>1.8</java.version>
+        <java.version>21</java.version>
         <maven.build.timestamp.format>yyyyMMddHHmm</maven.build.timestamp.format>
         <config.version>${maven.build.timestamp}</config.version>
     </properties>
-
 
     <build>
         <resources>
@@ -93,29 +91,20 @@
             </plugin>
         </plugins>
 
-        <extensions>
-            <extension>
-                <groupId>org.apache.maven.wagon</groupId>
-                <artifactId>wagon-ftp</artifactId>
-                <version>3.5.3</version>
-            </extension>
-        </extensions>
     </build>
 
     <repositories>
-        <!-- Spigot -->
         <repository>
-            <id>spigot-repo</id>
-            <url>https://hub.spigotmc.org/nexus/content/repositories/snapshots/</url>
+            <id>papermc</id>
+            <url>https://repo.papermc.io/repository/maven-public/</url>
         </repository>
     </repositories>
 
     <dependencies>
-        <!-- Spigot -->
         <dependency>
-            <groupId>org.spigotmc</groupId>
-            <artifactId>spigot-api</artifactId>
-            <version>1.21.5-R0.1-SNAPSHOT</version>
+            <groupId>io.papermc.paper</groupId>
+            <artifactId>paper-api</artifactId>
+            <version>1.21.4-R0.1-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
 

--- a/src/main/java/de/jeff_media/doorsreloaded/Main.java
+++ b/src/main/java/de/jeff_media/doorsreloaded/Main.java
@@ -11,7 +11,9 @@ import org.bukkit.block.data.Bisected;
 import org.bukkit.block.data.Openable;
 import org.bukkit.block.data.type.Door;
 import org.bukkit.plugin.java.JavaPlugin;
-import org.bukkit.scheduler.BukkitRunnable;
+import de.jeff_media.doorsreloaded.scheduler.FoliaPluginScheduler;
+import de.jeff_media.doorsreloaded.scheduler.PaperPluginScheduler;
+import de.jeff_media.doorsreloaded.scheduler.PluginScheduler;
 
 import java.io.IOException;
 
@@ -32,6 +34,8 @@ public class Main extends JavaPlugin {
             new PossibleNeighbour(1,0, Door.Hinge.LEFT, BlockFace.NORTH)
     };
     private boolean redstoneEnabled = false;
+    private PluginScheduler scheduler;
+    private boolean foliaEnvironment;
 
     public static Main getInstance() {
         return instance;
@@ -86,9 +90,20 @@ public class Main extends JavaPlugin {
         return redstoneEnabled;
     }
 
+    public PluginScheduler getScheduler() {
+        return scheduler;
+    }
+
+    public boolean isFoliaEnvironment() {
+        return foliaEnvironment;
+    }
+
     @Override
     public void onEnable() {
         instance = this;
+        foliaEnvironment = detectFoliaEnvironment();
+        scheduler = foliaEnvironment ? new FoliaPluginScheduler(this) : new PaperPluginScheduler(this);
+        getLogger().info(foliaEnvironment ? "Detected Folia environment; using region-aware scheduler." : "Using Paper/Purpur scheduler.");
         Config.init();
         reload();
         Bukkit.getPluginManager().registerEvents(new DoorListener(), this);
@@ -124,18 +139,25 @@ public class Main extends JavaPlugin {
         }
 
         boolean openNow = door.isOpen();
-        new BukkitRunnable() {
-            @Override
-                public void run() {
-                if (!(otherBlock.getBlockData() instanceof Door)) return;
-                Door newDoor = (Door) block.getBlockData();
-                if (!force && newDoor.isOpen() == openNow) {
-                    return;
-                }
-                toggleDoor(otherBlock, otherDoor, open);
+        scheduler.runAtBlockLater(block, 1L, () -> {
+            if (!(otherBlock.getBlockData() instanceof Door)) return;
+            Door newDoor = (Door) block.getBlockData();
+            if (!force && newDoor.isOpen() == openNow) {
+                return;
             }
-            }.runTaskLater(this, 1L);
+            toggleDoor(otherBlock, otherDoor, open);
+        });
 
+    }
+
+    private boolean detectFoliaEnvironment() {
+        try {
+            Class.forName("io.papermc.paper.threadedregions.scheduler.RegionScheduler");
+            Bukkit.getServer().getClass().getMethod("getRegionScheduler");
+            return true;
+        } catch (ReflectiveOperationException | SecurityException ignored) {
+            return false;
+        }
     }
 
 }

--- a/src/main/java/de/jeff_media/doorsreloaded/config/Config.java
+++ b/src/main/java/de/jeff_media/doorsreloaded/config/Config.java
@@ -20,6 +20,7 @@ public class Config {
     public static final String DEBUG = "debug";
     public static final String ALLOW_DOUBLEDOORS = "allow-doubledoors";
     public static final String ALLOW_IRONDOORS = "allow-opening-irondoors-with-hands";
+    public static final String AUTO_CLOSE = "autoclose";
 
     public static void init() {
         Main main = Main.getInstance();
@@ -36,5 +37,6 @@ public class Config {
         conf.addDefault(KNOCKING_REQUIRES_EMPTY_HAND, false);
         conf.addDefault(KNOCKING_REQUIRES_SHIFT, false);
         conf.addDefault(DEBUG, false);
+        conf.addDefault(AUTO_CLOSE, 0);
     }
 }

--- a/src/main/java/de/jeff_media/doorsreloaded/scheduler/FoliaPluginScheduler.java
+++ b/src/main/java/de/jeff_media/doorsreloaded/scheduler/FoliaPluginScheduler.java
@@ -1,0 +1,113 @@
+package de.jeff_media.doorsreloaded.scheduler;
+
+import org.bukkit.Bukkit;
+import org.bukkit.Location;
+import org.bukkit.Server;
+import org.bukkit.block.Block;
+import org.bukkit.plugin.Plugin;
+import org.bukkit.plugin.java.JavaPlugin;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.function.Consumer;
+
+public class FoliaPluginScheduler implements PluginScheduler {
+
+    private final JavaPlugin plugin;
+    private final Object regionScheduler;
+    private final Object globalScheduler;
+    private final Method regionRun;
+    private final Method regionRunDelayed;
+    private final Method regionRunAtFixedRate;
+    private final Method globalRun;
+    private final Method globalRunDelayed;
+    private final Method globalRunAtFixedRate;
+
+    public FoliaPluginScheduler(JavaPlugin plugin) {
+        this.plugin = plugin;
+        try {
+            Server server = Bukkit.getServer();
+            this.regionScheduler = server.getClass().getMethod("getRegionScheduler").invoke(server);
+            this.globalScheduler = server.getClass().getMethod("getGlobalRegionScheduler").invoke(server);
+
+            Class<?> pluginClass = Plugin.class;
+            Class<?> locationClass = Location.class;
+            Class<?> consumerClass = Consumer.class;
+
+            this.regionRun = regionScheduler.getClass().getMethod("run", pluginClass, locationClass, consumerClass);
+            this.regionRunDelayed = regionScheduler.getClass().getMethod("runDelayed", pluginClass, locationClass, consumerClass, long.class);
+            this.regionRunAtFixedRate = regionScheduler.getClass().getMethod("runAtFixedRate", pluginClass, locationClass, consumerClass, long.class, long.class);
+            this.globalRun = globalScheduler.getClass().getMethod("run", pluginClass, consumerClass);
+            this.globalRunDelayed = globalScheduler.getClass().getMethod("runDelayed", pluginClass, consumerClass, long.class);
+            this.globalRunAtFixedRate = globalScheduler.getClass().getMethod("runAtFixedRate", pluginClass, consumerClass, long.class, long.class);
+        } catch (ReflectiveOperationException exception) {
+            throw new IllegalStateException("Failed to access Folia scheduling APIs", exception);
+        }
+    }
+
+    @Override
+    public void runSync(Runnable task) {
+        invokeGlobal(globalRun, task);
+    }
+
+    @Override
+    public void runLater(Runnable task, long delayTicks) {
+        if (delayTicks <= 0L) {
+            runSync(task);
+            return;
+        }
+        invokeGlobal(globalRunDelayed, task, delayTicks);
+    }
+
+    @Override
+    public void runRepeating(Runnable task, long delayTicks, long periodTicks) {
+        invokeGlobal(globalRunAtFixedRate, task, delayTicks, periodTicks);
+    }
+
+    @Override
+    public void runAtBlock(Block block, Runnable task) {
+        invokeRegion(regionRun, block, task);
+    }
+
+    @Override
+    public void runAtBlockLater(Block block, long delayTicks, Runnable task) {
+        if (delayTicks <= 0L) {
+            runAtBlock(block, task);
+            return;
+        }
+        invokeRegion(regionRunDelayed, block, task, delayTicks);
+    }
+
+    private Consumer<Object> wrap(Runnable task) {
+        return scheduledTask -> task.run();
+    }
+
+    private void invokeGlobal(Method method, Runnable task, long... parameters) {
+        try {
+            Object[] args = new Object[2 + parameters.length];
+            args[0] = plugin;
+            args[1] = wrap(task);
+            for (int i = 0; i < parameters.length; i++) {
+                args[i + 2] = parameters[i];
+            }
+            method.invoke(globalScheduler, args);
+        } catch (IllegalAccessException | InvocationTargetException exception) {
+            throw new RuntimeException("Failed to schedule global task on Folia", exception);
+        }
+    }
+
+    private void invokeRegion(Method method, Block block, Runnable task, long... parameters) {
+        try {
+            Object[] args = new Object[3 + parameters.length];
+            args[0] = plugin;
+            args[1] = block.getLocation();
+            args[2] = wrap(task);
+            for (int i = 0; i < parameters.length; i++) {
+                args[i + 3] = parameters[i];
+            }
+            method.invoke(regionScheduler, args);
+        } catch (IllegalAccessException | InvocationTargetException exception) {
+            throw new RuntimeException("Failed to schedule region task on Folia", exception);
+        }
+    }
+}

--- a/src/main/java/de/jeff_media/doorsreloaded/scheduler/PaperPluginScheduler.java
+++ b/src/main/java/de/jeff_media/doorsreloaded/scheduler/PaperPluginScheduler.java
@@ -1,0 +1,42 @@
+package de.jeff_media.doorsreloaded.scheduler;
+
+import org.bukkit.Bukkit;
+import org.bukkit.block.Block;
+import org.bukkit.plugin.java.JavaPlugin;
+import org.bukkit.scheduler.BukkitScheduler;
+
+public class PaperPluginScheduler implements PluginScheduler {
+
+    private final JavaPlugin plugin;
+    private final BukkitScheduler scheduler;
+
+    public PaperPluginScheduler(JavaPlugin plugin) {
+        this.plugin = plugin;
+        this.scheduler = Bukkit.getScheduler();
+    }
+
+    @Override
+    public void runSync(Runnable task) {
+        scheduler.runTask(plugin, task);
+    }
+
+    @Override
+    public void runLater(Runnable task, long delayTicks) {
+        scheduler.runTaskLater(plugin, task, delayTicks);
+    }
+
+    @Override
+    public void runRepeating(Runnable task, long delayTicks, long periodTicks) {
+        scheduler.runTaskTimer(plugin, task, delayTicks, periodTicks);
+    }
+
+    @Override
+    public void runAtBlock(Block block, Runnable task) {
+        scheduler.runTask(plugin, task);
+    }
+
+    @Override
+    public void runAtBlockLater(Block block, long delayTicks, Runnable task) {
+        scheduler.runTaskLater(plugin, task, delayTicks);
+    }
+}

--- a/src/main/java/de/jeff_media/doorsreloaded/scheduler/PluginScheduler.java
+++ b/src/main/java/de/jeff_media/doorsreloaded/scheduler/PluginScheduler.java
@@ -1,0 +1,16 @@
+package de.jeff_media.doorsreloaded.scheduler;
+
+import org.bukkit.block.Block;
+
+public interface PluginScheduler {
+
+    void runSync(Runnable task);
+
+    void runLater(Runnable task, long delayTicks);
+
+    void runRepeating(Runnable task, long delayTicks, long periodTicks);
+
+    void runAtBlock(Block block, Runnable task);
+
+    void runAtBlockLater(Block block, long delayTicks, Runnable task);
+}

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -25,6 +25,9 @@ check-for-redstone: true
 # They need the permission "doorsreloaded.irondoors".
 allow-opening-irondoors-with-hands: false
 
+# Automatically closes iron doors and trapdoors after the given amount of seconds (0 to disable).
+autoclose: 0
+
 ###########################
 #         Knocking        #
 ###########################
@@ -46,13 +49,13 @@ knocking-requires-empty-hand: false
 knocking-requires-shift: false
 
 # Settings for the knocking sound
-# See here: https://hub.spigotmc.org/javadocs/spigot/org/bukkit/Sound.html
+# See the modern Paper API reference for valid sound keys.
 sound-knock-iron: "minecraft:entity.zombie.attack_iron_door"
 sound-knock-wood: "minecraft:item.shield.block"
 # A volume of 1.0 means 16 blocks, 2.0 means 32 blocks, etc.
 sound-knock-volume: 1.0
 sound-knock-pitch: 1.0
-# See here: https://hub.spigotmc.org/javadocs/spigot/org/bukkit/SoundCategory.html
+# See the modern Paper API reference for valid sound categories.
 sound-knock-category: BLOCKS
 
 ###########################

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,14 +1,15 @@
-main: ${spigot.main}
+main: ${plugin.main}
 name: ${project.name}
 version: ${project.version}
-description: "${project.description}"
-prefix: ${spigot.prefix}
+description: "Lightweight, modern door behavior optimized for Paper, Purpur, and Folia 1.21.x+."
+prefix: ${plugin.prefix}
 api-version: "1.21"
 authors:
   - mfnalex
   - JEFF Media GbR
 database: false
 load: POSTWORLD
+folia-supported: true
 commands:
   doorsreloaded:
     description: Reloads the configuration


### PR DESCRIPTION
## Summary
- switch the build and metadata to Paper-family targets and mark the plugin as Folia supported
- add a lightweight scheduler abstraction with Paper and Folia implementations and refactor door logic to use it safely
- refresh configuration/docs to document Paper, Purpur, and Folia support and Folia-aware behaviour

## Testing
- `mvn -B clean package` *(fails: Maven Central returned 403 Forbidden in this environment)*